### PR TITLE
Enabled extension support and workaround for docker/docker#4570

### DIFF
--- a/bin/prepare-env.sh
+++ b/bin/prepare-env.sh
@@ -12,13 +12,15 @@ if [ -f /data/data/mime.types ] ; then
   echo "removing stock data ..."
   rm -rf /var/www/twiki/data
   rm -rf /var/www/twiki/pub
+  rm -rf /var/www/twiki/lib
 else
   echo "moving stock data ..."
-  mv /var/www/twiki/data /var/www/twiki/pub /data/
+  cp -r /var/www/twiki/data /var/www/twiki/pub /var/www/twiki/lib /data/ && rm -rf /var/www/twiki/data /var/www/twiki/pub /var/www/twiki/lib
 fi
 
 # create the symlinks we need
 echo "linking data direcotires ..."
 ln -s /data/data /var/www/twiki/data
 ln -s /data/pub  /var/www/twiki/pub
+ln -s /data/lib  /var/www/twiki/lib
 echo "system is ready, have fun!"

--- a/perl/cpanfile
+++ b/perl/cpanfile
@@ -24,3 +24,4 @@ requires 'Digest::base';
 requires 'Digest::SHA1';
 requires 'Locale::Maketext::Lexicon';
 requires 'URI';
+requires 'LWP';


### PR DESCRIPTION
Include LWP CPAN module to allow extensions to be fetched
Include twiki/lib in persistent volume so extensions can be persisted
Changed mv to cp && rm as a workaround to docker/docker#4570